### PR TITLE
Fix crash when calling event handler functions

### DIFF
--- a/pkg/events/orgMprisMediaPlayer2EventHandler.go
+++ b/pkg/events/orgMprisMediaPlayer2EventHandler.go
@@ -34,7 +34,7 @@ func allRootProps(adapter types.OrgMprisMediaPlayer2Adapter) []string {
 
 func newOrgMprisMediaPlayer2EventHandler(mpris *server.Server) *orgMprisMediaPlayer2EventHandler {
 	eventHandler := orgMprisMediaPlayer2EventHandler{
-		conn:     mpris.Conn,
+		mpris:    mpris,
 		iface:    "org.mpris.MediaPlayer2",
 		adapter:  mpris.RootAdapter,
 		allProps: allRootProps(mpris.RootAdapter),
@@ -43,7 +43,7 @@ func newOrgMprisMediaPlayer2EventHandler(mpris *server.Server) *orgMprisMediaPla
 }
 
 type orgMprisMediaPlayer2EventHandler struct {
-	conn     *dbus.Conn
+	mpris    *server.Server
 	iface    string
 	adapter  types.OrgMprisMediaPlayer2Adapter
 	allProps []string
@@ -54,7 +54,7 @@ func (o *orgMprisMediaPlayer2EventHandler) EmitChanges(props []string) error {
 	if err != nil {
 		return err
 	}
-	return internal.EmitPropertiesChanged(o.conn, o.iface, changes)
+	return internal.EmitPropertiesChanged(o.mpris.Conn, o.iface, changes)
 }
 
 func (o *orgMprisMediaPlayer2EventHandler) OnAll() error {

--- a/pkg/events/orgMprisMediaPlayer2PlayerEventHandler.go
+++ b/pkg/events/orgMprisMediaPlayer2PlayerEventHandler.go
@@ -58,7 +58,7 @@ func newOrgMprisMediaPlayer2PlayerEventHandler(
 	mpris *server.Server,
 ) *orgMprisMediaPlayer2PlayerEventHandler {
 	eventHandler := orgMprisMediaPlayer2PlayerEventHandler{
-		conn:          mpris.Conn,
+		mpris:         mpris,
 		iface:         "org.mpris.MediaPlayer2.Player",
 		adapter:       mpris.PlayerAdapter,
 		allProps:      allPlayerProps(mpris.PlayerAdapter),
@@ -81,7 +81,7 @@ func newOrgMprisMediaPlayer2PlayerEventHandler(
 }
 
 type orgMprisMediaPlayer2PlayerEventHandler struct {
-	conn             *dbus.Conn
+	mpris            *server.Server
 	iface            string
 	adapter          types.OrgMprisMediaPlayer2PlayerAdapter
 	allProps         []string
@@ -99,7 +99,7 @@ func (o *orgMprisMediaPlayer2PlayerEventHandler) EmitChanges(props []string) err
 	if err != nil {
 		return err
 	}
-	return internal.EmitPropertiesChanged(o.conn, o.iface, changes)
+	return internal.EmitPropertiesChanged(o.mpris.Conn, o.iface, changes)
 }
 
 func (o *orgMprisMediaPlayer2PlayerEventHandler) OnEnded() error {
@@ -123,7 +123,7 @@ func (o *orgMprisMediaPlayer2PlayerEventHandler) OnTitle() error {
 }
 
 func (o *orgMprisMediaPlayer2PlayerEventHandler) OnSeek(position types.Microseconds) error {
-	o.conn.Emit("/org/mpris/MediaPlayer2", o.iface+".Seeked", int64(position))
+	o.mpris.Conn.Emit("/org/mpris/MediaPlayer2", o.iface+".Seeked", int64(position))
 	return o.EmitChanges(o.onSeekProps)
 }
 


### PR DESCRIPTION
Fixes: #3 

The DBus connection isn't created until Listen is called on the server, so if the event handler is created before, it had been given a nil *dbus.Conn. This change stores a reference to the server in the event handler types and accesses the conn through that so if it is created later it will have access.