### PR TITLE
Use proper map format for emitting Metadata on changes

### DIFF
--- a/internal/common.go
+++ b/internal/common.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 
 	"github.com/godbus/dbus/v5"
+	"github.com/quarckster/go-mpris-server/pkg/types"
 )
 
 func makeError(err error) *dbus.Error {
@@ -27,10 +28,17 @@ func Changes(adapter interface{}, props []string) (map[string]dbus.Variant, erro
 	changes := map[string]dbus.Variant{}
 	for _, prop := range props {
 		reflectValues := reflect.ValueOf(adapter).MethodByName(prop).Call([]reflect.Value{})
-		variant := dbus.MakeVariant(reflectValues[0].Interface())
 		err, _ := reflectValues[1].Interface().(error)
 		if err != nil {
 			return map[string]dbus.Variant{}, err
+		}
+
+		// need to handle Metadata as a special case since it needs to be converted to map
+		var variant dbus.Variant
+		if meta, ok := reflectValues[0].Interface().(types.Metadata); ok {
+			variant = dbus.MakeVariant(meta.MakeMap())
+		} else {
+			variant = dbus.MakeVariant(reflectValues[0].Interface())
 		}
 		changes[prop] = variant
 	}

--- a/pkg/events/common.go
+++ b/pkg/events/common.go
@@ -1,8 +1,14 @@
 package events
 
 import (
+	"errors"
+
 	"github.com/quarckster/go-mpris-server/pkg/server"
 	"github.com/quarckster/go-mpris-server/pkg/types"
+)
+
+var (
+	errNoConnection = errors.New("no dbus connection")
 )
 
 func NewEventHandler(mpris *server.Server) *EventHandler {

--- a/pkg/events/orgMprisMediaPlayer2EventHandler.go
+++ b/pkg/events/orgMprisMediaPlayer2EventHandler.go
@@ -1,7 +1,6 @@
 package events
 
 import (
-	"github.com/godbus/dbus/v5"
 	"github.com/quarckster/go-mpris-server/internal"
 	"github.com/quarckster/go-mpris-server/pkg/server"
 	"github.com/quarckster/go-mpris-server/pkg/types"
@@ -50,6 +49,9 @@ type orgMprisMediaPlayer2EventHandler struct {
 }
 
 func (o *orgMprisMediaPlayer2EventHandler) EmitChanges(props []string) error {
+	if o.mpris.Conn == nil {
+		return errNoConnection
+	}
 	changes, err := internal.Changes(o.adapter, props)
 	if err != nil {
 		return err

--- a/pkg/events/orgMprisMediaPlayer2PlayerEventHandler.go
+++ b/pkg/events/orgMprisMediaPlayer2PlayerEventHandler.go
@@ -1,7 +1,6 @@
 package events
 
 import (
-	"github.com/godbus/dbus/v5"
 	"github.com/quarckster/go-mpris-server/internal"
 	"github.com/quarckster/go-mpris-server/pkg/server"
 	"github.com/quarckster/go-mpris-server/pkg/types"
@@ -95,6 +94,9 @@ type orgMprisMediaPlayer2PlayerEventHandler struct {
 }
 
 func (o *orgMprisMediaPlayer2PlayerEventHandler) EmitChanges(props []string) error {
+	if o.mpris.Conn == nil {
+		return errNoConnection
+	}
 	changes, err := internal.Changes(o.adapter, props)
 	if err != nil {
 		return err
@@ -123,6 +125,9 @@ func (o *orgMprisMediaPlayer2PlayerEventHandler) OnTitle() error {
 }
 
 func (o *orgMprisMediaPlayer2PlayerEventHandler) OnSeek(position types.Microseconds) error {
+	if o.mpris.Conn == nil {
+		return errNoConnection
+	}
 	o.mpris.Conn.Emit("/org/mpris/MediaPlayer2", o.iface+".Seeked", int64(position))
 	return o.EmitChanges(o.onSeekProps)
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -62,6 +62,9 @@ func (s *Server) Listen() error {
 
 // Release the claimed bus name and close the connection.
 func (s *Server) Stop() error {
+	if s.Conn == nil {
+		return errors.New("server is not started")
+	}
 	var err error
 	err = internal.UnexportMethods(s.Conn)
 	if err != nil {


### PR DESCRIPTION
Fixes: #6 

We need to convert the Metadata struct into the proper map format before emitting it in Changes.

This also fixes an unused import error from my last PR (sorry about that!) and also returns errors instead of crashing if event handler functions are called before starting the server or if the server failed to establish a Dbus connection.