### PR TITLE
Add SetPosition and OpenUri methods to export table

### DIFF
--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -21,13 +21,15 @@ func exportOrgMprisMediaPlayer2(conn *dbus.Conn, r *OrgMprisMediaPlayer2) error 
 
 func exportOrgMprisMediaPlayer2Player(conn *dbus.Conn, p *OrgMprisMediaPlayer2Player) error {
 	return conn.ExportSubtreeMethodTable(map[string]interface{}{
-		"Next":      p.Next,
-		"Previous":  p.Previous,
-		"Pause":     p.Pause,
-		"PlayPause": p.PlayPause,
-		"Stop":      p.Stop,
-		"Play":      p.Play,
-		"Seek":      p.Seek,
+		"Next":        p.Next,
+		"Previous":    p.Previous,
+		"Pause":       p.Pause,
+		"PlayPause":   p.PlayPause,
+		"Stop":        p.Stop,
+		"Play":        p.Play,
+		"Seek":        p.Seek,
+		"SetPosition": p.SetPosition,
+		"OpenUri":     p.OpenUri,
 	}, "/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.Player")
 }
 


### PR DESCRIPTION
Fixes #8 

SetPosition and OpenUri were mistakenly omitted from the Player interface export table